### PR TITLE
fix: 删除total>1才显示分页器的判断

### DIFF
--- a/src/js/components/navigation/KLPager/index.html
+++ b/src/js/components/navigation/KLPager/index.html
@@ -1,4 +1,3 @@
-{#if total > 1}
 <div class="kl-pager kl-pager-{@(position)} {class}" is-dis={disabled} r-hide={!visible}>
     <div class="m-left-pager kl-pager-left">
         {#if !!pageSize || pageSize === 0}
@@ -53,4 +52,3 @@
     </ul>
 
 </div>
-{/if}


### PR DESCRIPTION
当设置pageSize大于sumTotal时，分页器隐藏导致无法再去设置pageSIze，只能重新刷新页面